### PR TITLE
fix outer header of acronyms (german) + dummy acronym for indentation

### DIFF
--- a/acronyms.tex
+++ b/acronyms.tex
@@ -1,10 +1,12 @@
 \clearpage
-\chapter*{Abkürzungsverzeichnis}	
+\chapter*{Abkürzungsverzeichnis}
 \addcontentsline{toc}{chapter}{Abkürzungsverzeichnis}
 
 
-\begin{acronym}[RDBMS]
+\begin{acronym}[A23456789] % longest acronym for correct indentation
+	\acro{A23456789}{This is just for indentation}
+
 	\acro{DHBW}{Duale Hochschule Baden-Württemberg}
 	\acro{RDBMS}{Relational Database Management System}
-	\acro{BMBF}{Bundesministerium für Bildung und Forschung}	
+	\acro{BMBF}{Bundesministerium für Bildung und Forschung}
 \end{acronym}

--- a/master.tex
+++ b/master.tex
@@ -68,7 +68,7 @@
 
 % 	Abkürzungsverzeichnis (siehe Datei acronyms.tex!)
 \input{acronyms}
-\ohead{Acronyms} % Neue Header-Definition
+\ohead{Abkürzungsverzeichnis} % Neue Header-Definition
 
 %--------------------------------
 % Start des Textteils der Arbeit


### PR DESCRIPTION
I suggest to rename the outer (right) header to `Abkürzungsverzeichnis` instead of `Acronyms` since the whole template is German.

I also added a dummy/placeholder acronym that can be used for indentation. Since it is not used in the text, it will not be displayed. But it helps because you don't need to change the specified acronym for indentation. You can just make it a bit longer in case you want to have more indentation.