### PR TITLE
add pdf bookmark for abstract and table of contents

### DIFF
--- a/master.tex
+++ b/master.tex
@@ -49,9 +49,12 @@
 \input{nondisclosurenotice}
 
 %	Kurzfassung
+\pdfbookmark{Kurzfassung}{kurzfassung-bookmark}
 \input{abstract}
 
 %	Inhaltsverzeichnis
+\clearpage
+\pdfbookmark{Inhaltsverzeichnis}{toc-bookmark}
 \tableofcontents
 
 %	Abbildungsverzeichnis


### PR DESCRIPTION
Currently there are no pdf-bookmarks created for abstract and table of contents. I added the corresponding code so that the bookmarks are created and you can jump to the corresponding page directly.
![image](https://user-images.githubusercontent.com/10072099/82123705-0eaa7a80-979b-11ea-9131-22c8356d9027.png)

The first argument of `\pdfbookmark` (part of hyperref-package) defines the displayed text, the second argument is just an internal unique name.
