### PR TITLE
add .idx and .synctex to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.log
 *.lof
 *.glo
+*.idx
 *.ist
 *.lot
 *.loa
@@ -24,5 +25,6 @@
 *.xml
 *.xdy 
 ._*
+*.synctex(busy)
 *.synctex.gz
 !**/img/*.pdf


### PR DESCRIPTION
idx file seems to be generated by index creation.
.synctex(busy) is created temporarily in the folder and will later be either renamed or moved into the .gz version. However if we execute `git add .` and a latex compile at the same time it might end up in the repo. so i would propose to just ignore it.