### PR TITLE
Move language settings above package imports

### DIFF
--- a/LaTeX/config.tex
+++ b/LaTeX/config.tex
@@ -7,6 +7,15 @@
 % markiert sind.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+%%
+%% @stud
+%%
+%% LANGUAGE SETTINGS
+\usepackage[ngerman]{babel} 	        % german language
+\usepackage[german=quotes]{csquotes} 	% correct quoting using \enquote{}
+%\usepackage[english]{babel}          % english language
+%\usepackage{csquotes} 	              % correct quoting using \enquote{}
+
 \usepackage{makeidx}                  % allows index generation
 \usepackage{listings}	                %Format Listings properly
 \usepackage{lipsum}                   % Blindtext
@@ -57,15 +66,6 @@
 % Typewriter
 %\renewcommand*{\familydefault}{\ttdefault}
 %\addtokomafont{disposition}{\ttfamily}
-
-%%
-%% @stud
-%%
-%% LANGUAGE SETTINGS
-\usepackage[ngerman]{babel} 	        % german language
-\usepackage[german=quotes]{csquotes} 	% correct quoting using \enquote{}
-%\usepackage[english]{babel}          % english language
-%\usepackage{csquotes} 	              % correct quoting using \enquote{}
 
 %%
 %% @stud


### PR DESCRIPTION
This resolves `\autoref` not displaying the reference in the language set by the `babel` package.
The problem stems from the import order of the `babel` and `hyperref ` packages.
If `hyperref` is importet before `babel`, like it currently is, the `babel` language settings don't affect the `hyperref` settings. 
___
### Example:

**Current state:**
```
\usepackage[hidelinks=true]{hyperref}
\usepackage[ngerman]{babel}
```
Results in `\autoref{figure}` being displayed as `Figure 1`

**State with fix:**
```
\usepackage[ngerman]{babel}
\usepackage[hidelinks=true]{hyperref}
```
Results in `\autoref{figure}` being displayed as `Abbildung 1`
