### PR TITLE
Default to German settings as stated in README

### DIFF
--- a/LaTeX/ewerkl.tex
+++ b/LaTeX/ewerkl.tex
@@ -6,7 +6,7 @@
 % Erklärung im Inhaltsverzeichnis.
 
 % \addcontentsline{toc}{chapter}{Ehrenwörtliche Erklärung}
-Ich versichere hiermit, dass ich die vorliegende Arbeit mit dem Titel ``\textit{\DerTitelDerArbeit}'' selbstständig verfasst und 
+Ich versichere hiermit, dass ich die vorliegende Arbeit mit dem Titel \enquote{\textit{\DerTitelDerArbeit}} selbstständig verfasst und 
 keine anderen als die angegebenen Quellen und Hilfsmittel benutzt habe. Ich versichere zudem, dass die eingereichte elektronische 
 Fassung mit der gedruckten Fassung übereinstimmt.
 

--- a/LaTeX/master.tex
+++ b/LaTeX/master.tex
@@ -32,10 +32,10 @@
 %
 % @stud: Sprache ggf. anpassen
 %
-%\usepackage[ngerman]{babel} 	        % german language
-%\usepackage[german=quotes]{csquotes} 	% correct quoting using \enquote{}
-\usepackage[english]{babel}          % english language
-\usepackage{csquotes} 	              % correct quoting using \enquote{}
+\usepackage[ngerman]{babel} 	        % german language
+\usepackage[german=quotes]{csquotes} 	% correct quoting using \enquote{}
+%\usepackage[english]{babel}          % english language
+%\usepackage{csquotes} 	              % correct quoting using \enquote{}
 
 %%%%%%%%%%%%%
 %% ZITIERSTIL


### PR DESCRIPTION
The README and the section _Text in Anführungszeichen_ of the template state that the template defaults to German language settings. That was in fact not the case.

Also fixed one instance of manual quotes instead of \enquote{} in ewerkl.tex